### PR TITLE
Make use of JAVA_HOME

### DIFF
--- a/libmatthew-libcgi/pom.xml
+++ b/libmatthew-libcgi/pom.xml
@@ -32,7 +32,7 @@
               <includes><include>**/*.c</include></includes>
             </source>
           </sources>
-          <jdkIncludePath>/usr/lib/jvm/java-6-sun-1.6.0.22/include/</jdkIncludePath>
+          <jdkIncludePath>${java.home}/../include</jdkIncludePath>
           <javahOS>linux</javahOS>
           <compilerStartOptions>
             <compilerStartOption>-Wall -Os -pedantic -Werror -std=c99 -fpic -fno-stack-protector</compilerStartOption>

--- a/libmatthew-libunix/pom.xml
+++ b/libmatthew-libunix/pom.xml
@@ -35,7 +35,7 @@
               <includes><include>**/*.c</include></includes>
             </source>
           </sources>
-          <jdkIncludePath>/usr/lib/jvm/java-6-sun-1.6.0.22/include/</jdkIncludePath>
+          <jdkIncludePath>${java.home}/../include</jdkIncludePath>
           <javahOS>linux</javahOS>
           <compilerStartOptions>
             <compilerStartOption>-Wall -Os -pedantic -Werror -std=c99 -fpic -fno-stack-protector</compilerStartOption>


### PR DESCRIPTION
This pull-request makes use of JAVA_HOME, instead of the hard-coded JDK path.
